### PR TITLE
Tied typed array

### DIFF
--- a/lib/List/Objects/WithUtils/Array/Typed.pm
+++ b/lib/List/Objects/WithUtils/Array/Typed.pm
@@ -70,6 +70,8 @@ List::Objects::WithUtils::Array::Typed - Type-checking array objects
 A L<List::Objects::WithUtils::Array> subclass providing type-checking via
 L<Type::Tiny> types.
 
+This module requires L<Type::Tie>.
+
 The first argument passed to the constructor should be a L<Type::Tiny> type:
 
   use Types::Standard -all;

--- a/t/typecheck.t
+++ b/t/typecheck.t
@@ -2,7 +2,7 @@
 BEGIN {
   unless (
     eval {; require List::Objects::Types; 1 } && !$@
-    && eval {; require Types::Standard; 1 }   && !$@
+    && eval {; require Types::Standard; require Type::Tie; 1 }   && !$@
   ) {
     require Test::More;
     Test::More::plan(skip_all => 


### PR DESCRIPTION
This introduces an extra dependency (Type::Tie, which itself has a dependency on Hash::FieldHash), so I'd certainly understand if you didn't want to accept it.

However, I think it has some advantages over the current typed array implementation:
- It's about 60% faster, according to my very basic benchmarking of

``` perl
my $arr = array_of(Int, 0..99);
$arr->push(0..9) for 0..99
```
- It makes List::Objects::WithUtils::Array::Typed into a fairly trivial subclass of List::Objects::WithUtils::Array; apart from the constructor you no longer need to override any methods. (I think this is the main reason for the speed-up.)
- This is the reason I implemented it to begin with: **using the `@{}` overload no longer bypasses the type checks and coercions**, so people can happily do `push @{$typedarray}, $value`.
